### PR TITLE
add pageheader background gradient moonrise

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -56,8 +56,11 @@ a {
 .page-header {
   color: #fff;
   text-align: center;
-  background-color: #159957;
-  background-image: linear-gradient(120deg, #155799, #159957); }
+  background: #DAE2F8; /* fallback for old browsers */
+  background: -webkit-linear-gradient(to left, #DAE2F8 , #D6A4A4); /* Chrome 10-25, Safari 5.1-6 */
+  background: linear-gradient(to left, #DAE2F8 , #D6A4A4); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
+       
+}
 
 @media screen and (min-width: 64em) {
   .page-header {


### PR DESCRIPTION
# http://uigradients.com/

background: #DAE2F8; /\* fallback for old browsers _/
background: -webkit-linear-gradient(to left, #DAE2F8 , #D6A4A4); /_ Chrome 10-25, Safari 5.1-6 _/
background: linear-gradient(to left, #DAE2F8 , #D6A4A4); /_ W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
